### PR TITLE
Router bindings

### DIFF
--- a/example/App.res
+++ b/example/App.res
@@ -16,6 +16,10 @@ app->post("/ping", (req, res) => {
   }
 })
 
+app->all("/allRoute", (_req, res) => {
+  res->status(200)->json({"ok": true})->ignore
+})
+
 app->useWithError((err, _req, res, _next) => {
   Js.Console.error(err)
   let _ = res->status(500)->endWithData("An error occured")

--- a/example/App.res
+++ b/example/App.res
@@ -2,6 +2,20 @@ open Express
 
 let app = expressCjs()
 
+let router = app->router
+
+router->Router.use((req, _res, next) => {
+  Js.log(req)
+  next()
+})
+
+router->Router.useWithError((err, _req, res, _next) => {
+  Js.Console.error(err)
+  let _ = res->status(500)->endWithData("An error occured")
+})
+
+app->useRouter(router)
+
 app->use(jsonMiddleware())
 
 app->get("/", (_req, res) => {

--- a/src/Express.res
+++ b/src/Express.res
@@ -42,6 +42,7 @@ external staticMiddlewareWithOptions: (string, {..}) => middleware = "static"
 @send external del: (express, string, handler) => unit = "del"
 @send external patch: (express, string, handler) => unit = "patch"
 @send external put: (express, string, handler) => unit = "put"
+@send  external all: (express, string, handler) => unit = "all"
 
 @send external enable: (express, string) => unit = "enable"
 @send external enabled: (express, string) => bool = "enabled"

--- a/src/Express.res
+++ b/src/Express.res
@@ -142,3 +142,33 @@ let is = (req, value) => req->is(value)->parseValue
 @send external status: (res, int) => res = "status"
 @send external \"type": (res, string) => string = "type"
 @send external vary: (res, string) => res = "vary"
+
+
+module Router = {
+  type t
+  @send external use: (t, middleware) => unit = "use"
+  @send external useWithPath: (t, string, middleware) => unit = "use"
+
+  @send external useWithError: (t, middlewareWithError) => unit = "use"
+  @send external useWithPathAndError: (t, string, middlewareWithError) => unit = "use"
+
+  @send external get: (t, string, handler) => unit = "get"
+  @send external post: (t, string, handler) => unit = "post"
+  @send external delete: (t, string, handler) => unit = "delete"
+  @deprecated("Express 5.0 deprecates app.del(), use app.delete() instead")
+  @send external del: (t, string, handler) => unit = "del"
+  @send external patch: (t, string, handler) => unit = "patch"
+  @send external put: (t, string, handler) => unit = "put"
+  @send  external all: (t, string, handler) => unit = "all"
+
+  type paramHandler = (req, res, unit => unit, string, string) => unit
+
+  @send external param: (t, string, paramHandler) => unit = "param"
+  @deprecated("deprecated as of v4.11.0")
+  @send external defineParamBehavior: ((string, 'a) => paramHandler) => unit = "param"
+
+  @send external route: string => t = "route"
+}
+
+@send external useRouter: (express, Router.t) => unit = "use"
+@send external router: express => Router.t = "Router"

--- a/src/Express.res
+++ b/src/Express.res
@@ -42,7 +42,7 @@ external staticMiddlewareWithOptions: (string, {..}) => middleware = "static"
 @send external del: (express, string, handler) => unit = "del"
 @send external patch: (express, string, handler) => unit = "patch"
 @send external put: (express, string, handler) => unit = "put"
-@send  external all: (express, string, handler) => unit = "all"
+@send external all: (express, string, handler) => unit = "all"
 
 @send external enable: (express, string) => unit = "enable"
 @send external enabled: (express, string) => bool = "enabled"
@@ -143,7 +143,6 @@ let is = (req, value) => req->is(value)->parseValue
 @send external \"type": (res, string) => string = "type"
 @send external vary: (res, string) => res = "vary"
 
-
 module Router = {
   type t
   @send external use: (t, middleware) => unit = "use"
@@ -159,7 +158,7 @@ module Router = {
   @send external del: (t, string, handler) => unit = "del"
   @send external patch: (t, string, handler) => unit = "patch"
   @send external put: (t, string, handler) => unit = "put"
-  @send  external all: (t, string, handler) => unit = "all"
+  @send external all: (t, string, handler) => unit = "all"
 
   type paramHandler = (req, res, unit => unit, string, string) => unit
 

--- a/src/Express.resi
+++ b/src/Express.resi
@@ -42,6 +42,7 @@ external staticMiddlewareWithOptions: (string, {..}) => middleware = "static"
 @send external del: (express, string, handler) => unit = "del"
 @send external patch: (express, string, handler) => unit = "patch"
 @send external put: (express, string, handler) => unit = "put"
+@send  external all: (express, string, handler) => unit = "all"
 
 @send external enable: (express, string) => unit = "enable"
 @send external enabled: (express, string) => bool = "enabled"

--- a/src/Express.resi
+++ b/src/Express.resi
@@ -126,3 +126,32 @@ let is: (req, string) => option<string>
 @send external status: (res, int) => res = "status"
 @send external \"type": (res, string) => string = "type"
 @send external vary: (res, string) => res = "vary"
+
+module Router: {
+  type t
+  @send external use: (t, middleware) => unit = "use"
+  @send external useWithPath: (t, string, middleware) => unit = "use"
+
+  @send external useWithError: (t, middlewareWithError) => unit = "use"
+  @send external useWithPathAndError: (t, string, middlewareWithError) => unit = "use"
+
+  @send external get: (t, string, handler) => unit = "get"
+  @send external post: (t, string, handler) => unit = "post"
+  @send external delete: (t, string, handler) => unit = "delete"
+  @deprecated("Express 5.0 deprecates app.del(), use app.delete() instead")
+  @send external del: (t, string, handler) => unit = "del"
+  @send external patch: (t, string, handler) => unit = "patch"
+  @send external put: (t, string, handler) => unit = "put"
+  @send  external all: (t, string, handler) => unit = "all"
+
+  type paramHandler = (req, res, unit => unit, string, string) => unit
+
+  @send external param: (t, string, paramHandler) => unit = "param"
+  @deprecated("deprecated as of v4.11.0")
+  @send external defineParamBehavior: ((string, 'a) => paramHandler) => unit = "param"
+
+  @send external route: string => t = "route"
+}
+
+@send external useRouter: (express, Router.t) => unit = "use"
+@send external router: express => Router.t = "Router"

--- a/src/Express.resi
+++ b/src/Express.resi
@@ -42,7 +42,7 @@ external staticMiddlewareWithOptions: (string, {..}) => middleware = "static"
 @send external del: (express, string, handler) => unit = "del"
 @send external patch: (express, string, handler) => unit = "patch"
 @send external put: (express, string, handler) => unit = "put"
-@send  external all: (express, string, handler) => unit = "all"
+@send external all: (express, string, handler) => unit = "all"
 
 @send external enable: (express, string) => unit = "enable"
 @send external enabled: (express, string) => bool = "enabled"
@@ -142,7 +142,7 @@ module Router: {
   @send external del: (t, string, handler) => unit = "del"
   @send external patch: (t, string, handler) => unit = "patch"
   @send external put: (t, string, handler) => unit = "put"
-  @send  external all: (t, string, handler) => unit = "all"
+  @send external all: (t, string, handler) => unit = "all"
 
   type paramHandler = (req, res, unit => unit, string, string) => unit
 


### PR DESCRIPTION
I followed [this](https://expressjs.com/en/4x/api.html#router) description, so this code only has methods described there.

I've seen you have removed sub-modules at some point, but it seemed to be more natural for Routers, because some names match, and the typical scenario for Routers is creating another file per route, so you can `open Express.Router` in this file, I think.

I am open to discuss problems you see here, I am thinking maybe instead of duplicating those route.METHOD bindings, we could do something more clever with module Functors and other techniques.