### PR TITLE
feat: Server Sent Events support

### DIFF
--- a/example/App.res
+++ b/example/App.res
@@ -39,6 +39,21 @@ app->useWithError((err, _req, res, _next) => {
   let _ = res->status(500)->endWithData("An error occured")
 })
 
+app->get("/stream", (req, res) => {
+  res->set("Cache-Control", "no-cache")
+  res->set("Content-Type", "text/event-stream")
+  res->set("Connection", "keep-alive")
+  req->flushHeaders->ignore
+
+  res->on(#close(() => {
+    Js.Console.log("Stream Ended")
+  }))
+
+  res->write(`data: Hello World`)->ignore
+  res->write(`data: Hello World`)->ignore
+  res->end->ignore
+})
+
 let port = 8081
 let _ = app->listenWithCallback(port, _ => {
   Js.Console.log(`Listening on http://localhost:${port->Belt.Int.toString}`)

--- a/example/App.res
+++ b/example/App.res
@@ -45,9 +45,9 @@ app->get("/stream", (req, res) => {
   res->set("Connection", "keep-alive")
   req->flushHeaders->ignore
 
-  res->on(#close(() => {
+  res->onClose(() => {
     Js.Console.log("Stream Ended")
-  }))
+  })
 
   res->write(`data: Hello World`)->ignore
   res->write(`data: Hello World`)->ignore

--- a/src/Express.res
+++ b/src/Express.res
@@ -133,9 +133,7 @@ let is = (req, value) => req->is(value)->parseValue
 @send external jsonp: (res, 'a) => res = "jsonp"
 @send external links: (res, Js.Dict.t<string>) => res = "links"
 @send external location: (res, string) => res = "location"
-@send external on: (res, @string [
-  | #close(unit => unit)
-]) => unit = "on"
+@send external onClose: (res, @as("close") _, unit => unit) => unit = "on"
 @send external redirect: (res, string) => res = "redirect"
 @send external redirectWithStatusCode: (res, ~statusCode: int, string) => res = "redirect"
 @send external send: (res, 'a) => res = "send"

--- a/src/Express.res
+++ b/src/Express.res
@@ -104,6 +104,7 @@ let acceptsCharset = (req, value) => req->acceptsCharset(value)->parseValue
 let acceptsEncodings = (req, value) => req->acceptsEncodings(value)->parseValue
 let acceptsLanguages = (req, value) => req->acceptsLanguages(value)->parseValue
 
+@send external flushHeaders: req => 'a = "flushHeaders"
 @send external getRequestHeader: (req, string) => option<string> = "get"
 @send external is: (req, string) => 'a = "is"
 
@@ -132,6 +133,9 @@ let is = (req, value) => req->is(value)->parseValue
 @send external jsonp: (res, 'a) => res = "jsonp"
 @send external links: (res, Js.Dict.t<string>) => res = "links"
 @send external location: (res, string) => res = "location"
+@send external on: (res, @string [
+  | #close(unit => unit)
+]) => unit = "on"
 @send external redirect: (res, string) => res = "redirect"
 @send external redirectWithStatusCode: (res, ~statusCode: int, string) => res = "redirect"
 @send external send: (res, 'a) => res = "send"
@@ -142,6 +146,7 @@ let is = (req, value) => req->is(value)->parseValue
 @send external status: (res, int) => res = "status"
 @send external \"type": (res, string) => string = "type"
 @send external vary: (res, string) => res = "vary"
+@send external write: (res, string) => bool = "write"
 
 module Router = {
   type t

--- a/src/Express.resi
+++ b/src/Express.resi
@@ -117,9 +117,7 @@ let is: (req, string) => option<string>
 @send external jsonp: (res, 'a) => res = "jsonp"
 @send external links: (res, Js.Dict.t<string>) => res = "links"
 @send external location: (res, string) => res = "location"
-@send external on: (res, @string [
-  #close(unit => unit)
-]) => unit = "on"
+@send external onClose: (res, @as("close") _, unit => unit) => unit = "on"
 @send external redirect: (res, string) => res = "redirect"
 @send external redirectWithStatusCode: (res, ~statusCode: int, string) => res = "redirect"
 @send external send: (res, 'a) => res = "send"

--- a/src/Express.resi
+++ b/src/Express.resi
@@ -89,6 +89,7 @@ let acceptsCharset: (req, array<string>) => option<string>
 let acceptsEncodings: (req, array<string>) => option<string>
 let acceptsLanguages: (req, array<string>) => option<string>
 
+@send external flushHeaders: req => 'a = "flushHeaders"
 @send external getRequestHeader: (req, string) => option<string> = "get"
 
 let is: (req, string) => option<string>
@@ -116,6 +117,9 @@ let is: (req, string) => option<string>
 @send external jsonp: (res, 'a) => res = "jsonp"
 @send external links: (res, Js.Dict.t<string>) => res = "links"
 @send external location: (res, string) => res = "location"
+@send external on: (res, @string [
+  #close(unit => unit)
+]) => unit = "on"
 @send external redirect: (res, string) => res = "redirect"
 @send external redirectWithStatusCode: (res, ~statusCode: int, string) => res = "redirect"
 @send external send: (res, 'a) => res = "send"
@@ -126,6 +130,7 @@ let is: (req, string) => option<string>
 @send external status: (res, int) => res = "status"
 @send external \"type": (res, string) => string = "type"
 @send external vary: (res, string) => res = "vary"
+@send external write: (res, string) => bool = "write"
 
 module Router: {
   type t


### PR DESCRIPTION
I need SSE support, so I've added the few methods that I use. [I've followed this short code sample](https://masteringjs.io/tutorials/express/server-sent-events)

The express Request object extends native Node Request, so most of these methods come from that

- `flushHeaders` - [Official Node Docs](https://nodejs.org/api/http.html#requestflushheaders), pushes the headers to the client and starts the stream
- `on(#close)` - [Offical Node Docs](https://nodejs.org/api/http.html#event-close_1). Fired when the `EventStream` ends from the frontend, needed for cleaning up any intervals/subscriptions going on in the request
- `write(string)` - [Official Node Docs](https://nodejs.org/api/http.html#responsewritechunk-encoding-callback) Pushes out a new line to the SSE
 
[Reference to SSE in Express](https://masteringjs.io/tutorials/express/server-sent-events)

JS output from App.res example

```js
app.get("/stream", (function (req, res) {
        res.set("Cache-Control", "no-cache");
        res.set("Content-Type", "text/event-stream");
        res.set("Connection", "keep-alive");
        req.flushHeaders();
        res.on("close", (function (param) {
                console.log("Stream Ended");
                
              }));
        res.write("data: Hello World");
        res.write("data: Hello World");
        res.end();
        
      }));
```